### PR TITLE
Handle removed app

### DIFF
--- a/src/similarium/exceptions.py
+++ b/src/similarium/exceptions.py
@@ -44,6 +44,10 @@ class NotInChannel(SlackException):
     pass
 
 
+class AccountInactive(SlackException):
+    pass
+
+
 class GameNotRegistered(SlackException):
     pass
 

--- a/src/similarium/game.py
+++ b/src/similarium/game.py
@@ -1,7 +1,12 @@
 from slack_sdk.errors import SlackApiError
 
 from similarium import db
-from similarium.exceptions import ChannelNotFound, GameNotRegistered, NotInChannel
+from similarium.exceptions import (
+    AccountInactive,
+    ChannelNotFound,
+    GameNotRegistered,
+    NotInChannel,
+)
 from similarium.logging import logger
 from similarium.models import Channel, Game
 from similarium.models.similarity_range import SimilarityRange
@@ -84,6 +89,9 @@ async def start_game(channel_id: str):
             case "not_in_channel":
                 # Needs to be invited
                 raise NotInChannel()
+            case "account_inactive":
+                # Similarium user has been removed from the team
+                raise AccountInactive()
         return
 
     game.thread_ts = resp["ts"]

--- a/src/similarium/models/channel.py
+++ b/src/similarium/models/channel.py
@@ -16,6 +16,7 @@ class Channel(Base):
     team_id = sa.Column(sa.Text, nullable=False)
     # The hour to post the daily puzzle, on UTC+0
     hour = sa.Column(sa.Integer, nullable=False)
+    active = sa.Column(sa.Boolean, default=True)
 
     @classmethod
     async def by_id(
@@ -27,7 +28,9 @@ class Channel(Base):
 
     @classmethod
     async def by_hour(cls, hour: int, /, *, session: AsyncSession) -> list[Channel]:
-        return (await session.scalars(select(cls).where(cls.hour == hour))).all()
+        return (
+            await session.scalars(select(cls).where(cls.hour == hour, cls.active))
+        ).all()
 
     def __repr__(self) -> str:
         return f"<Channel (id={self.id})>"

--- a/src/similarium/tasks.py
+++ b/src/similarium/tasks.py
@@ -1,35 +1,33 @@
 import asyncio
 import datetime as dt
+from typing import Awaitable, Callable
 
 import sentry_sdk
 
 from similarium import db
+from similarium.exceptions import AccountInactive
 from similarium.game import end_game, start_game
 from similarium.logging import logger
 from similarium.models import Channel
 from similarium.utils import get_seconds_left_of_hour
 
 
-async def create_games(hour: int) -> None:
-    """Create the games for a certain hour on all active channels"""
-    async with db.session() as session:
-        channels = await Channel.by_hour(hour, session=session)
-
-    logger.debug(f"Ending games in {len(channels)} channels")
-    # End active games
+async def action(
+    channels: list[Channel], func: Callable[[str], Awaitable[None]]
+) -> None:
     results = await asyncio.gather(
-        *[end_game(channel.id) for channel in channels], return_exceptions=True
+        *[func(channel.id) for channel in channels if channel.active],
+        return_exceptions=True,
     )
-    for exc in filter(bool, results):
-        sentry_sdk.capture_exception(exc)
-
-    logger.debug(f"Starting games in {len(channels)} channels")
-    # Start new games
-    results = await asyncio.gather(
-        *[start_game(channel.id) for channel in channels], return_exceptions=True
-    )
-    for exc in filter(bool, results):
-        sentry_sdk.capture_exception(exc)
+    for channel, exc in filter(lambda _: bool(_[1]), zip(channels, results)):
+        if isinstance(exc, AccountInactive):
+            # Account is inactive on channel, mark as such
+            async with db.session() as session:
+                channel.active = False  # type: ignore
+                await session.commit()
+        else:
+            # Unexpected error
+            sentry_sdk.capture_exception(exc)
 
 
 async def hourly_game_creator() -> None:
@@ -45,10 +43,14 @@ async def hourly_game_creator() -> None:
             await asyncio.sleep(sleep_time)
 
             current_hour = dt.datetime.now(dt.timezone.utc).hour
+            async with db.session() as session:
+                channels = await Channel.by_hour(current_hour, session=session)
 
-            await create_games(current_hour)
+            logger.debug(f"Ending games in {len(channels)} channels")
+            await action(channels, end_game)
 
-            # TODO Timeouts?
+            logger.debug(f"Starting games in {len(channels)} channels")
+            await action(channels, start_game)
         except Exception as e:
             logger.error("Got exception in hourly task runner", exc_info=e)
             sentry_sdk.capture_exception(e)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -62,3 +62,10 @@ async def user_id(db) -> AsyncIterator[str]:
         await session.commit()
 
     yield _user.id
+
+
+@pytest.fixture(autouse=True)
+async def slack_app() -> AsyncIterator[mock.AsyncMock]:
+    """Mock slack app completely"""
+    with mock.patch("similarium.slack.AsyncApp") as m:
+        yield m

--- a/tests/integration/test_tasks.py
+++ b/tests/integration/test_tasks.py
@@ -1,0 +1,75 @@
+import asyncio
+from unittest import mock
+
+import pytest
+
+from similarium.models import Channel
+from similarium.tasks import create_games
+
+
+async def test_create_games_handles_one_task_erroring(
+    db,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+
+    channels = [
+        Channel(id="channel_1", team_id="team_x", hour=1),
+        Channel(id="channel_2", team_id="team_x", hour=1),
+        Channel(id="channel_3", team_id="team_x", hour=1),
+    ]
+    async with db.session() as s:
+        s.add_all(channels)
+        await s.commit()
+
+    pings = []
+
+    async def mock_end_game(channel_id: str) -> None:
+        if channel_id == "channel_1":
+            raise Exception("Uh oh")
+        await asyncio.sleep(0.1)
+        pings.append(channel_id)
+
+    monkeypatch.setattr("similarium.tasks.end_game", mock_end_game)
+    monkeypatch.setattr(
+        "similarium.tasks.start_game", mock.AsyncMock(return_value=None)
+    )
+
+    await create_games(1)
+
+    assert len(pings) == 2
+    assert "channel_2" in pings
+    assert "channel_3" in pings
+
+
+async def test_create_games_reports_errors_to_sentry(
+    db,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+
+    channels = [
+        Channel(id="channel_1", team_id="team_x", hour=1),
+        Channel(id="channel_2", team_id="team_x", hour=1),
+        Channel(id="channel_3", team_id="team_x", hour=1),
+    ]
+    async with db.session() as s:
+        s.add_all(channels)
+        await s.commit()
+
+    pings = []
+    exception = Exception("Uh oh")
+
+    async def mock_end_game(channel_id: str) -> None:
+        if channel_id == "channel_1":
+            raise exception
+        await asyncio.sleep(0.1)
+        pings.append(channel_id)
+
+    monkeypatch.setattr("similarium.tasks.end_game", mock_end_game)
+    monkeypatch.setattr(
+        "similarium.tasks.start_game", mock.AsyncMock(return_value=None)
+    )
+
+    with mock.patch("similarium.tasks.sentry_sdk") as mock_sentry:
+        await create_games(1)
+
+    mock_sentry.capture_exception.assert_called_once_with(exception)

--- a/tests/integration/test_tasks.py
+++ b/tests/integration/test_tasks.py
@@ -1,17 +1,12 @@
 import asyncio
 from unittest import mock
 
-import pytest
-
+from similarium.exceptions import AccountInactive
 from similarium.models import Channel
-from similarium.tasks import create_games
+from similarium.tasks import action
 
 
-async def test_create_games_handles_one_task_erroring(
-    db,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-
+async def test_create_games_handles_one_task_erroring(db) -> None:
     channels = [
         Channel(id="channel_1", team_id="team_x", hour=1),
         Channel(id="channel_2", team_id="team_x", hour=1),
@@ -23,29 +18,20 @@ async def test_create_games_handles_one_task_erroring(
 
     pings = []
 
-    async def mock_end_game(channel_id: str) -> None:
+    async def mock_action(channel_id: str) -> None:
         if channel_id == "channel_1":
             raise Exception("Uh oh")
         await asyncio.sleep(0.1)
         pings.append(channel_id)
 
-    monkeypatch.setattr("similarium.tasks.end_game", mock_end_game)
-    monkeypatch.setattr(
-        "similarium.tasks.start_game", mock.AsyncMock(return_value=None)
-    )
-
-    await create_games(1)
+    await action(channels, mock_action)
 
     assert len(pings) == 2
     assert "channel_2" in pings
     assert "channel_3" in pings
 
 
-async def test_create_games_reports_errors_to_sentry(
-    db,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-
+async def test_create_games_reports_errors_to_sentry(db) -> None:
     channels = [
         Channel(id="channel_1", team_id="team_x", hour=1),
         Channel(id="channel_2", team_id="team_x", hour=1),
@@ -58,18 +44,36 @@ async def test_create_games_reports_errors_to_sentry(
     pings = []
     exception = Exception("Uh oh")
 
-    async def mock_end_game(channel_id: str) -> None:
+    async def mock_action(channel_id: str) -> None:
         if channel_id == "channel_1":
             raise exception
         await asyncio.sleep(0.1)
         pings.append(channel_id)
 
-    monkeypatch.setattr("similarium.tasks.end_game", mock_end_game)
-    monkeypatch.setattr(
-        "similarium.tasks.start_game", mock.AsyncMock(return_value=None)
-    )
-
     with mock.patch("similarium.tasks.sentry_sdk") as mock_sentry:
-        await create_games(1)
+        await action(channels, mock_action)
 
     mock_sentry.capture_exception.assert_called_once_with(exception)
+
+
+async def test_create_games_marks_channels_as_inactive_if_account_inactive(db) -> None:
+    channels = [
+        Channel(id="channel_1", team_id="team_x", hour=1),
+        Channel(id="channel_2", team_id="team_x", hour=1),
+        Channel(id="channel_3", team_id="team_x", hour=1),
+    ]
+    async with db.session() as s:
+        s.add_all(channels)
+        await s.commit()
+
+    async def mock_action(channel_id: str) -> None:
+        if channel_id == "channel_1":
+            raise AccountInactive()
+
+    with mock.patch("similarium.tasks.sentry_sdk") as mock_sentry:
+        await action(channels, mock_action)
+
+    assert not mock_sentry.capture_exception.called
+    assert not channels[0].active
+    assert channels[1].active
+    assert channels[1].active


### PR DESCRIPTION
When an app has been removed from a team, mark the channel as inactive and stop trying to post games to it.