### PR TITLE
Get game without puzzle number

### DIFF
--- a/src/similarium/app.py
+++ b/src/similarium/app.py
@@ -67,7 +67,6 @@ async def handle_some_action(ack, respond, body, client):
                 session=session,
                 channel_id=channel,
                 thread_ts=message_ts,
-                puzzle_number=puzzle_number,
             )
             if game is None:
                 raise NotFound(

--- a/src/similarium/models/game.py
+++ b/src/similarium/models/game.py
@@ -71,16 +71,14 @@ class Game(Base):
         *,
         channel_id: str,
         thread_ts: str,
-        puzzle_number: int,
         session: AsyncSession,
     ) -> Optional[Game]:
-        logger.debug(f"Getting Game: {channel_id=} {thread_ts=} {puzzle_number=}")
+        logger.debug(f"Getting Game: {channel_id=} {thread_ts=}")
         stmt = (
             select(cls)
             .where(
                 cls.channel_id == channel_id,
                 cls.thread_ts == thread_ts,
-                cls.puzzle_number == puzzle_number,
             )
             .options(selectinload(cls.guesses))
             .options(selectinload(cls.similarity_range))


### PR DESCRIPTION
A game is unique to channel_id + thread_ts, the puzzle number is not required.

Fixes #49