### PR TITLE
Use hint_seeker.user_id instead of hint_seeker.user.id

### DIFF
--- a/src/similarium/models/game.py
+++ b/src/similarium/models/game.py
@@ -249,7 +249,7 @@ class Game(Base):
         winners = []
         # Get hint seekers map so we can mark if the winner saw the hint
         hint_seekers = {
-            hint_seeker.user.id: hint_seeker.guess_idx
+            hint_seeker.user_id: hint_seeker.guess_idx
             for hint_seeker in self.hint_seekers
         }
         for idx, winner in enumerate(self.winners):


### PR DESCRIPTION
Prevents the need to load the user in the relationship, since the association has the user_id on it